### PR TITLE
CI: auto-release on tag + README version badge

### DIFF
--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -1,0 +1,70 @@
+name: release-on-tag
+on:
+  push:
+    tags:
+      - "v*"
+permissions:
+  contents: write
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Derive version from tag
+        id: meta
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "TAG=${TAG}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+      - name: Locate addon source
+        id: locate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -d "AltClickStatus" ]]; then
+            echo "src=AltClickStatus" >> $GITHUB_OUTPUT
+          elif [[ -d "Interface/AddOns/AltClickStatus" ]]; then
+            echo "src=Interface/AddOns/AltClickStatus" >> $GITHUB_OUTPUT
+          else
+            echo "::error::Could not find AltClickStatus folder. Ensure the repo contains 'AltClickStatus/' or 'Interface/AddOns/AltClickStatus/'."
+            exit 1
+          fi
+      - name: Prepare package
+        shell: bash
+        run: |
+          set -euo pipefail
+          SRC="${{ steps.locate.outputs.src }}"
+          ADDON="AltClickStatus"
+          mkdir -p pkg/"${ADDON}"
+          rsync -a --delete --exclude ".git" --exclude ".github" --exclude "pkg" "${SRC}/" "pkg/${ADDON}/"
+          if grep -qE '^##\s*Version:' "pkg/${ADDON}/${ADDON}.toc"; then
+            sed -i -E "s/^(##\s*Version:)\s*.*/\1 ${{ env.VERSION }}/" "pkg/${ADDON}/${ADDON}.toc"
+          else
+            echo "## Version: ${{ env.VERSION }}" >> "pkg/${ADDON}/${ADDON}.toc"
+          fi
+          cd pkg
+          ZIP="${ADDON}_${{ env.TAG }}.zip"
+          zip -r "$ZIP" "${ADDON}"
+          echo "ZIP_PATH=${PWD}/${ZIP}" >> $GITHUB_ENV
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: AltClickStatus_${{ env.TAG }}.zip
+          path: ${{ env.ZIP_PATH }}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ZIP_PATH }}
+          name: Alt-Click Status ${{ env.TAG }}
+          tag_name: ${{ env.TAG }}
+          body: |
+            Alt-Click Status ${{ env.TAG }}
+            Automatically packaged on tag.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 RELEASE_CHECKLIST.md
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Alt‑Click Status (Classic Era + ElvUI)
+<!-- Version & CI badges -->
+[![Latest Release](https://img.shields.io/github/v/release/patrickdoane/AltClickStatus?display_name=tag&sort=semver)](https://github.com/patrickdoane/AltClickStatus/releases/latest)
+[![Release on tag](https://img.shields.io/badge/CI-Release%20on%20tag-blue)](.github/workflows/release-on-tag.yml)
 
 Alt‑Click Status is a World of Warcraft **Classic Era** addon that lets you quickly communicate the status of your **spells** and **character** via **Alt + Left‑click**—inspired by Dota 2’s ping/announce system.
 


### PR DESCRIPTION
CI: auto-package & attach ZIP on tags + README version badge

**What**
- Add **release-on-tag** workflow:
  - Triggers on `v*` tags
  - Finds `AltClickStatus/` (or `Interface/AddOns/AltClickStatus/`), bumps the TOC `## Version:` inside the package, zips, and attaches to a GitHub Release
  - Uploads the ZIP as a workflow artifact too
- Add README badges:
  - Latest release tag (dynamic)
  - CI workflow badge

**How to use**
1) Merge this PR.
2) Tag a commit: `git tag -a v0.3.0b -m "Alt-Click Status v0.3.0b" && git push origin v0.3.0b`
3) The action will publish a release with `AltClickStatus_v0.3.0b.zip` attached.

**Notes**
- The TOC `## Version:` is only adjusted inside the release package to match the tag; your repo files remain unchanged.
- If your addon lives elsewhere, adjust the `Locate addon source` step.
