### PR TITLE
Ci/release on tag fix v3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# .gitattributes
+*.lua text eol=lf
+*.toc text eol=lf
+.pkgmeta text eol=lf

--- a/.github/workflows/release-on-tag.yml
+++ b/.github/workflows/release-on-tag.yml
@@ -160,6 +160,41 @@ jobs:
           echo "Generated .pkgmeta:"
           cat .pkgmeta
 
+      - name: 'Debug: show what will be packaged'
+        shell: bash
+        run: |
+          echo "Repo root contents:"
+          ls -la
+          echo "AltClickStatus folder:"
+          ls -la AltClickStatus || true
+          echo "TOC head:"
+          sed -n '1,20p' AltClickStatus/AltClickStatus.toc
+
+      - name: 'Write clean .pkgmeta for packager'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .pkgmeta <<'EOF'
+          package-as: AltClickStatus
+
+          ignore:
+            - .git
+            - .github
+            - pkg
+          EOF
+          # Normalize line endings to LF and show control chars (should be clean)
+          perl -pi -e 's/\r\n/\n/g' .pkgmeta
+          echo ".pkgmeta content (visible control chars):"
+          sed -n '1,50p' .pkgmeta | cat -v 
+
+      - name: 'Sanity: ensure addon folder exists'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f AltClickStatus/AltClickStatus.toc || (echo "TOC missing"; exit 1)
+          # Ensure the folder exists and is non-empty
+          find AltClickStatus -maxdepth 1 -type f | sed -n '1,20p'
+
       - name: 'Upload to CurseForge (BigWigs Packager)'
         uses: BigWigsMods/packager@v2
         env:


### PR DESCRIPTION
Attempts to fix release-on-tag action failures by generating a clean .pkgmeta for BigWigs packager. Also adds a .gitattributes file to normalize line endings for the project.