### PR TITLE
fix(input): mouse-only Alt+click; ignore Alt+keybinds (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and [Semantic Versioning](https://semver.org/).
 - 
 
 ### Fixed
-- 
+- Alt + keybind (e.g., Alt+1) no longer triggers announcements. Announcements now fire only on Alt+Left mouse clicks. (#12)
 
 ### Removed
 - 


### PR DESCRIPTION
Fix: Alt + keybind keystrokes were triggering announcements (#12)

**Root cause**
Hotkey activations with Alt (e.g., Alt+1) satisfied `IsAltKeyDown()` and looked like Alt+Click to our logic.

**Solution**
- Integrate a mouse-origin gate directly in `AltClickStatus.lua`:
  - Mark **real** Alt+Left mouse downs on action buttons.
  - Gate the announce path (`AltClickStatus_AltClick`) on that mark.
  - Clear per-button flags after clicks.
- No TOC changes required (single-file update).

**User impact**
- Alt+hotkeys (Alt+1, etc.) will no longer announce.
- Alt+Left mouse clicks continue to announce as expected.

**Testing**
- Classic Era (11507), Blizzard + ElvUI bars.

/cc #12
