### PR TITLE
fix(input): strict mouse-only gate; stop Alt+keybind announces (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and [Semantic Versioning](https://semver.org/).
 - 
 
 ### Fixed
-- 
+- Alt + keybind (e.g., Alt+1) no longer triggers announcements. Announcements now fire only on Alt+Left mouse clicks. (#12)
 
 ### Removed
 - 


### PR DESCRIPTION
Fix: STRICT mouse-only gate; Alt+keybinds never announce (#12)

**What**
- Require BOTH:
  1) `PreClick` saw a **LeftButton** with the mouse physically down (`IsMouseButtonDown("LeftButton")`), and
  2) `OnMouseDown` stamped the **same frame** within 0.50s.

- Macro entry (`AltClickStatus_AltClick`) validates this and clears flags.

**Why**
- Some paths execute our macro for Alt+hotkeys; PreClick+OnMouseDown together are definitive for real mouse clicks.

**Result**
- Alt+1 (and other keybinds) never announce.
- Alt+Left mouse clicks announce as expected.
- Works on Blizzard and ElvUI bars (Classic Era).

/cc #12
