### PR TITLE
feat(announce): show 'Not enough <Resource>' when insufficient power (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - Alt + keybind (e.g., Alt+1) no longer triggers announcements. Announcements now fire only on Alt+Left mouse clicks. (#12)
+- Announcements now report **Not enough _Resource_** (Mana/Rage/Energy/Focus) when a spell is otherwise ready but you lack resources. Includes `(have/need)` when available via `GetSpellPowerCost`. (#17)
 
 ### Removed
 - 


### PR DESCRIPTION
Fix: show 'Not enough <Resource>' when out of mana/energy/rage (#17)

**Behavior**
- If a spell is otherwise ready (not on cooldown/GCD) but cannot be cast due to insufficient resources, announce:
  `Spell Name > Not enough Mana · In/Out of Range`
  (Resource name matches the player's current power: Mana, Rage, Energy, Focus, etc.)
- When available, the message includes current/required: `Not enough Mana (20/50)`.

**Implementation**
- Use `IsUsableSpell(spell)` to detect insufficient power.
- Prefer cooldown/charges messages when those states are active, but **before** saying "Ready", check resources.
- Attempt to read required cost via `GetSpellPowerCost` when available; otherwise omit the numbers.

**Notes**
- Works for Classic Era + ElvUI bars.
- No SavedVariables or TOC changes.

/cc #17
