### PR TITLE
feat(cfg): add persisted /acs showrange on|off|toggle; default OFF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and [Semantic Versioning](https://semver.org/).
 ### Fixed
 - Alt + keybind (e.g., Alt+1) no longer triggers announcements. Announcements now fire only on Alt+Left mouse clicks. (#12)
 - Announcements now report **Not enough _Resource_** (Mana/Rage/Energy/Focus) when a spell is otherwise ready but you lack resources. Includes `(have/need)` when available via `GetSpellPowerCost`. (#17)
+- Hidden runtime toggle `/acs showrange on|off|toggle` to include/exclude range text (default OFF).
 
 ### Removed
 - 


### PR DESCRIPTION
Hidden toggle: `/acs showrange on|off|toggle`

**What**
- Adds a runtime toggle to include/exclude range text in announcements.
- Default remains OFF (no range text). This matches the recent change removing range text globally.
- No SavedVariables yet (non-persistent by design).

**Why**
- Let testers or advanced users re-enable range without code changes while we iterate on UX.

**Notes**
- Keeps strict mouse-only gate (#12) and 'Not enough <Resource>' behavior (#17).
- Usage is intentionally not shown in `/acs` help.
