### PR TITLE
feat(elvui): Alt+LeftClick on ElvUI unit frames announces HP/Power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 ### Added
-- 
+- ElvUI unit frames: Alt+LeftClick announces HP/Power (player, target, focus, pet).
 
 ### Changed
 - 


### PR DESCRIPTION
Feat: ElvUI unit frames Alt+LeftClick announcements

**What**
- Alt+LeftClick on ElvUI unit frames now announces unit status:
  - Player: `I have <HP%> HP, <Power%> <PowerName>.`
  - Target/Focus/Pet: `<Name>: <HP%> HP, <Power%> <PowerName>.`

**Details**
- Hooks `ElvUF_Player`, `ElvUF_Target`, `ElvUF_Focus`, `ElvUF_Pet` via `OnMouseUp` (no protected attribute changes).
- Respects `/acs toggle unit` (enabled by default).
- Does not include range text (that’s for spell announcements only).

**Why**
- Restores the expected Dota-style quick comms for unit frames under ElvUI.
