### PR TITLE
feat(unitframes): Alt+LeftClick on party/raid frames (ElvUI + Blizzar…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ This format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 
 ### Added
-
--
+- Alt+LeftClick party/raid unit frames (ElvUI party/raid incl. Raid40, Blizzard party).
 
 
 
@@ -39,8 +38,7 @@ This format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 
 ### Notes for Users
-
--
+- Announce teammate HP/Power by Alt+LeftClicking their unit frame in party/raid/battlegrounds.
 
 
 


### PR DESCRIPTION
### Summary
- **ElvUI party**: `ElvUF_PartyGroup1UnitButton1..5` and `ElvUF_PartyUnitButton1..5` now announce on Alt+LeftClick.
- **ElvUI raid**: `ElvUF_RaidGroup1..8UnitButton1..5`, `ElvUF_Raid40UnitButton1..40`, and `ElvUF_Raid40Group1..8UnitButton1..5` supported.
- **Blizzard party**: `PartyMemberFrame1..4` supported.
- Adds an out-of-combat safe enumerator fallback to hook any ElvUI unit buttons with valid `.unit` (covers profile/theme variations).
- Re-hooks automatically on roster/zone changes with a small delay to catch late-spawned frames (BGs).

### Behavior
- Announces: `<Name>: <HP%> HP, <Power%> <PowerName>.`
- Does not interfere with targeting/casting; only Alt+Left mouse clicks trigger announcements.

### Testing
- BG/raid: Alt+LeftClick several raid buttons (including `Raid40`) — expect announcements.
- 5-man: Alt+LeftClick party frames (ElvUI & Blizzard) — expect announcements.
- Reload or change layouts; `/acs hook elv` re-applies hooks OOC.

Closes #26.

## Type
- [ ] fix
- [x] feat
- [ ] chore

## Checklist
- [x] Linted / tested locally
- [x] Updated CHANGELOG.md
