### PR TITLE
feat: announce auras on alt-click

### DIFF
--- a/AltClickStatus/AltClickStatus.lua
+++ b/AltClickStatus/AltClickStatus.lua
@@ -554,6 +554,19 @@ local function AnnounceUnit(unit)
     end
 end
 
+local function AnnounceAura(unit, index, filter)
+    if not unit or not index then return end
+    local name, _, count, _, duration, expires = UnitAura(unit, index, filter)
+    if not name then return end
+    if unit == "player" then
+        local remain = (expires and duration and duration > 0) and (expires - GetTime()) or 0
+        safeSend(("%s > %ds left"):format(name, math.floor(remain + 0.5)))
+    else
+        local stacks = (count and count > 1) and (" x" .. count) or ""
+        safeSend(("%s%s"):format(name, stacks))
+    end
+end
+
 local function hookElvUFFrame(name, unit)
     local f = _G[name]
     if not f or f.__ACS_UFHooked or not f.HookScript then return false end
@@ -680,6 +693,70 @@ local function configureBlizzardPartyFrames()
     if hooked > 0 then dprint("Blizzard party frames hooked:", hooked) end
 end
 
+local function hookAuraButton(btn, unit, filter)
+    if not btn or btn.__ACS_AuraHooked or not btn.HookScript then return false end
+    btn:HookScript("OnMouseUp", function(self, mouseBtn)
+        if not A.ENABLE_UNITFRAMES then return end
+        if mouseBtn ~= "LeftButton" or not IsAltKeyDown() then return end
+        AnnounceAura(unit, self:GetID(), filter)
+    end)
+    btn.__ACS_AuraHooked = true
+    return true
+end
+
+local function configurePlayerAuras()
+    local hooked = 0
+    local max = BUFF_MAX_DISPLAY or 40
+    for i = 1, max do
+        local btn = _G[("BuffButton%u"):format(i)]
+        if hookAuraButton(btn, "player", "HELPFUL") then hooked = hooked + 1 end
+    end
+    if hooked > 0 then dprint("Player auras hooked:", hooked) end
+end
+
+local function configureTargetDebuffs()
+    local hooked = 0
+    local max = MAX_TARGET_DEBUFFS or 16
+    for i = 1, max do
+        local btn = _G[("TargetFrameDebuff%u"):format(i)]
+        if hookAuraButton(btn, "target", "HARMFUL") then hooked = hooked + 1 end
+    end
+    if hooked > 0 then dprint("Target debuffs hooked:", hooked) end
+end
+
+local function configureElvUIPlayerAuras()
+    if not IsAddOnLoaded("ElvUI") then return end
+    local hooked = 0
+    local max = BUFF_MAX_DISPLAY or 40
+    for i = 1, max do
+        local btn = _G[("ElvUIPlayerBuffsAuraButton%u"):format(i)]
+        if hookAuraButton(btn, "player", "HELPFUL") then hooked = hooked + 1 end
+    end
+    if hooked > 0 then dprint("ElvUI player auras hooked:", hooked) end
+end
+
+local function configureElvUITargetBuffs()
+    if not IsAddOnLoaded("ElvUI") then return end
+    local hooked = 0
+    local max = MAX_TARGET_BUFFS or 40
+    for i = 1, max do
+        local btn = _G[("ElvUF_TargetBuffsButton%u"):format(i)]
+        if hookAuraButton(btn, "target", "HELPFUL") then hooked = hooked + 1 end
+    end
+    if hooked > 0 then dprint("ElvUI target buffs hooked:", hooked) end
+end
+
+local function configureElvUITargetDebuffs()
+    if not IsAddOnLoaded("ElvUI") then return end
+    local hooked = 0
+    local max = MAX_TARGET_DEBUFFS or 40
+    for i = 1, max do
+        local btn = _G[("ElvUF_TargetDebuffsButton%u"):format(i)]
+        if hookAuraButton(btn, "target", "HARMFUL") then hooked = hooked + 1 end
+    end
+    if hooked > 0 then dprint("ElvUI target debuffs hooked:", hooked) end
+end
+
 -- Orchestration
 local pending=false
 local function ensureConfigured()
@@ -689,6 +766,11 @@ local function ensureConfigured()
     configureElvUIUnitFrames()
     configureElvUIRaidPartyFrames()
     configureBlizzardPartyFrames()
+    configurePlayerAuras()
+    configureTargetDebuffs()
+    configureElvUIPlayerAuras()
+    configureElvUITargetBuffs()
+    configureElvUITargetDebuffs()
 end
 A:RegisterEvent("PLAYER_LOGIN"); A:RegisterEvent("PLAYER_ENTERING_WORLD"); A:RegisterEvent("ADDON_LOADED"); A:RegisterEvent("GROUP_ROSTER_UPDATE"); A:RegisterEvent("ZONE_CHANGED_NEW_AREA")
 A:SetScript("OnEvent", function(self,event,arg1)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Quickly announce your character state with **Alt+LeftClick** — inspired by Dot
   * Macro-aware: understands `/cast` and `/castsequence` with conditionals (e.g., `[@cursor]`, empty `[]`).
   * `/use` support: item **names**, `item:ID`, and **trinket slots** `13` / `14`.
 * **ElvUI unitframes:** Alt+LeftClick announces **HP%** and **Power%** for player/target/focus/pet.
+* **Auras:** Alt+LeftClick your buff row or a target's buff/debuff to share remaining time or stack count — works with Blizzard and ElvUI widgets.
 * **Mouse-only gate:** Only **Alt+LeftClick** counts — **Alt+keybinds (e.g., Alt+1)** won’t trigger announcements.
 * **Range suffix toggle:** Hidden by default; opt-in with `/acs showrange on`.
 * **Non-casting:** Alt+LeftClick does **not** activate the action; it only announces.
@@ -58,6 +59,11 @@ Quickly announce your character state with **Alt+LeftClick** — inspired by Dot
 ### ElvUI unit frames
 
 * **Alt+LeftClick** on Player / Target / Focus / Pet frames to announce HP% and Power%.
+
+### Auras
+
+* **Alt+LeftClick** your buff row to share remaining duration. Supports both Blizzard and ElvUI aura bars.
+* **Alt+LeftClick** a target's buff or debuff to report its name and stacks (Blizzard UI: debuffs only).
 
 ### Slash commands
 
@@ -113,6 +119,7 @@ Quickly announce your character state with **Alt+LeftClick** — inspired by Dot
 * **Items say `Not in Bags` but you have it:** If it’s a brand new drop, the client cache may be cold — use the item once or reopen bags.
 * **Range always `N/A`:** Some items don’t report range from action slots; try a spell on the bar to verify range suffix.
 * **Alt+keybind announces:** Update to a version ≥ `v0.3.0k` where the **mouse-only gate** is enforced.
+* **Need the frame name under the cursor:** Some clients omit `GetMouseFocus`; run `/run print(MouseFocus and MouseFocus:GetName() or "nil")` while hovering to report it.
 
 ---
 


### PR DESCRIPTION
## Summary
- announce player buffs with remaining time
- report target debuff stacks via alt-click
- hook ElvUI aura buttons for alt-click announcements
- document fallback MouseFocus macro for frame names

## Testing
- `luac -p AltClickStatus/AltClickStatus.lua`


------
https://chatgpt.com/codex/tasks/task_e_68bd53ed2d388328ad5fddc89968b95e