### PR TITLE
Fix ElvUI target buff announcements

### DIFF
--- a/AltClickStatus/AltClickStatus.lua
+++ b/AltClickStatus/AltClickStatus.lua
@@ -798,12 +798,14 @@ A:SetScript("OnEvent", function(self,event,arg1)
             C_Timer.After(0, function()
                 configureTargetDebuffs()
                 configureElvUITargetDebuffs()
+                configureElvUITargetBuffs()
             end)
         end
     elseif event == "PLAYER_TARGET_CHANGED" then
         C_Timer.After(0, function()
             configureTargetDebuffs()
             configureElvUITargetDebuffs()
+            configureElvUITargetBuffs()
         end)
     end
 end)


### PR DESCRIPTION
## Summary
- Ensure ElvUI target buff buttons are re-hooked when target or aura changes

## Testing
- `luac -p AltClickStatus/AltClickStatus.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c031619b6c8328a252774b24e663e1