### PR TITLE
feat: detail target aura announcements

### DIFF
--- a/AltClickStatus/AltClickStatus.lua
+++ b/AltClickStatus/AltClickStatus.lua
@@ -563,7 +563,14 @@ local function AnnounceAura(unit, index, filter)
         safeSend(("%s > %ds left"):format(name, math.floor(remain + 0.5)))
     else
         local stacks = (count and count > 1) and (" x" .. count) or ""
-        safeSend(("%s%s"):format(name, stacks))
+        local remain = (expires and duration and duration > 0) and (expires - GetTime()) or nil
+        local me = UnitName("player") or "Player"
+        local guild = GetGuildInfo("player")
+        if guild then me = string.format("%s (%s)", me, guild) end
+        local tgt = UnitName(unit) or unit
+        local aff = UnitIsFriend("player", unit) and "Ally" or "Enemy"
+        local remainTxt = remain and string.format(" (%d seconds remaining)", math.floor(remain + 0.5)) or ""
+        safeSend(string.format("Allies %s %s %s affected by %s%s%s", me, aff, tgt, name, stacks, remainTxt))
     end
 end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,9 @@ This format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 
 
+
 ### Changed
-
--
-
-
+- Target buff/debuff announcements now detail player and target with remaining duration.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- mimic Dota-style messages for target buffs/debuffs, including player name, target, stacks, and remaining time
- document change in changelog

## Testing
- `luac -p AltClickStatus/AltClickStatus.lua`
- `luacheck AltClickStatus/AltClickStatus.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c061b7c8388328a3154c59b4bfebf4