### PR TITLE
fix: simplify target aura announcements

### DIFF
--- a/AltClickStatus/AltClickStatus.lua
+++ b/AltClickStatus/AltClickStatus.lua
@@ -563,7 +563,10 @@ local function AnnounceAura(unit, index, filter)
         safeSend(("%s > %ds left"):format(name, math.floor(remain + 0.5)))
     else
         local stacks = (count and count > 1) and (" x" .. count) or ""
-        safeSend(("%s%s"):format(name, stacks))
+        local remain = (expires and duration and duration > 0) and (expires - GetTime()) or nil
+        local tgt = UnitName(unit) or unit
+        local remainTxt = remain and string.format(" (%d seconds remaining)", math.floor(remain + 0.5)) or ""
+        safeSend(string.format("%s affected by %s%s%s", tgt, name, stacks, remainTxt))
     end
 end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,9 @@ This format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 
 
+
 ### Changed
-
--
-
-
+- Target buff/debuff announcements now show the target with remaining duration.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- streamline target aura announcements to only report the affected target, aura name, stacks and remaining time
- document simplified format in changelog

## Testing
- `luac -p AltClickStatus/AltClickStatus.lua`
- `luacheck AltClickStatus/AltClickStatus.lua` *(170 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c061b7c8388328a3154c59b4bfebf4