### PR TITLE
fix: simplify target aura announcements

### DIFF
--- a/AltClickStatus/AltClickStatus.lua
+++ b/AltClickStatus/AltClickStatus.lua
@@ -27,6 +27,17 @@ local function safeSend(msg)
     SendChatMessage(msg, chooseChannel())
 end
 
+local function formatTime(secs)
+    secs = math.floor(secs + 0.5)
+    local h = math.floor(secs/3600); secs = secs % 3600
+    local m = math.floor(secs/60); local s = secs % 60
+    local t = {}
+    if h > 0 then table.insert(t, h .. "h") end
+    if m > 0 then table.insert(t, m .. "m") end
+    if s > 0 or #t == 0 then table.insert(t, s .. "s") end
+    return table.concat(t, " ")
+end
+
 -- Mouse-only gate (issue #12)
 local MOUSE_WINDOW = 0.50 -- seconds
 local function ACS_PreClick(self, button)
@@ -560,10 +571,13 @@ local function AnnounceAura(unit, index, filter)
     if not name then return end
     if unit == "player" then
         local remain = (expires and duration and duration > 0) and (expires - GetTime()) or 0
-        safeSend(("%s > %ds left"):format(name, math.floor(remain + 0.5)))
+        safeSend(("%s > %s left"):format(name, formatTime(remain)))
     else
         local stacks = (count and count > 1) and (" x" .. count) or ""
-        safeSend(("%s%s"):format(name, stacks))
+        local remain = (expires and duration and duration > 0) and (expires - GetTime()) or nil
+        local tgt = UnitName(unit) or unit
+        local remainTxt = remain and string.format(" (%s remaining)", formatTime(remain)) or ""
+        safeSend(string.format("%s affected by %s%s%s", tgt, name, stacks, remainTxt))
     end
 end
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,9 @@ This format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 
 
+
 ### Changed
-
--
-
-
+- Target buff/debuff announcements now show the target with remaining duration formatted with hours and minutes when applicable.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- format target aura remaining duration using h/m/s
- document duration format in changelog

## Testing
- `luac -p AltClickStatus/AltClickStatus.lua`
- `luacheck AltClickStatus/AltClickStatus.lua` *(170 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c061b7c8388328a3154c59b4bfebf4